### PR TITLE
BSC-12819: for schema show of a RPC, recurse into full schema

### DIFF
--- a/bin/pybsn-repl
+++ b/bin/pybsn-repl
@@ -78,7 +78,7 @@ def show_schema(root, max_depth=1, verbose=True):
         else:
             return t['leafType'].lower()
 
-    def traverse(node, depth=0, name="root"):
+    def traverse(node, depth=0, name="root", max_depth=None):
         def output(*s, **kw):
             d = kw.get("depth", depth)
             print(" " * (d * 2) + ' '.join(s))
@@ -118,13 +118,13 @@ def show_schema(root, max_depth=1, verbose=True):
             output(name, "(rpc)", description)
             for name, item in ( ("in", "inputSchemaNode"), ("out", "outputSchemaNode")):
                 if item in node:
-                    traverse(node[item], depth+1, name)
+                    traverse(node[item], depth+1, name, max_depth=None)
                 else:
                     output(name, "(NONE)", depth=depth+1)
         else:
             assert False, "unknown node type %s" % node['nodeType']
 
-    traverse(root.schema(), name=root._path)
+    traverse(root.schema(), name=root._path, max_depth=max_depth)
 
 config = Config()
 config.TerminalInteractiveShell.banner1 = "pybsn REPL - Run %help for help"


### PR DESCRIPTION
With this patch, the full schema for RPC is shown:

```
In [1]: root.os.upgrade.copy_image#
controller/os/upgrade/copy-image (rpc)
  # Handles the validation of a copied image, represented as a file
  # URL on this node's filesystem. Returns information about the
  # image, including its validation status.
  in
    source-url : string
      # The source of the image as an local file URL
  out
    # The images available on this node for use with upgrade
    checksum : string
      # The image checksum (SHA256) encoded as a hex string
    [...]
```