### PR TITLE
BSC-12819: pybsn-repl; show schema - correct max_depth recursion

### DIFF
--- a/bin/pybsn-repl
+++ b/bin/pybsn-repl
@@ -106,21 +106,22 @@ def show_schema(root, max_depth=1, verbose=True):
             if node['nodeType'] == 'CONTAINER':
                 output(name, description)
             for child_name, child in node.get('childNodes', {}).items():
-                traverse(child, depth+1, child_name)
+                traverse(child, depth+1, child_name, max_depth=max_depth)
         elif node['nodeType'] == 'LIST':
             output(name, "(list)", description)
-            traverse(node['listElementSchemaNode'], depth, name)
+            traverse(node['listElementSchemaNode'], depth, name, max_depth=max_depth)
         elif node['nodeType'] == 'LEAF':
             output(name, ":", pretty_type(node), config, description)
         elif node['nodeType'] == 'LEAF_LIST':
             output(name, ":", "list of", pretty_type(node['leafSchemaNode']), config, description)
         elif node['nodeType'] == 'RPC':
             output(name, "(rpc)", description)
-            for name, item in ( ("in", "inputSchemaNode"), ("out", "outputSchemaNode")):
-                if item in node:
-                    traverse(node[item], depth+1, name, max_depth=None)
-                else:
-                    output(name, "(NONE)", depth=depth+1)
+            if max_depth is not None and depth < max_depth:
+                for name, item in ( ("in", "inputSchemaNode"), ("out", "outputSchemaNode")):
+                    if item in node:
+                        traverse(node[item], depth+1, name, max_depth=None)
+                    else:
+                        output(name, "(NONE)", depth=depth+1)
         else:
             assert False, "unknown node type %s" % node['nodeType']
 


### PR DESCRIPTION
The problem was that the `max_depth` parameter of `traverse` (introduced in #20) wasn't included for the recursive invocations of `traverse` for other data structures (e.g., containers, lists). Thus it would default to None and pybsn-repl would show the whole schema. 