### PR TITLE
BSC-12875: handle return 204s from RPCs correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   # betamax on py2 produces brokenness; we want to rip it out, but
   # for now let's run at least the python 3 unit tests
-  #- "2.7"
+  - "2.7"
   - "3.5"
 # command to install dependencies
 install: 

--- a/bin/pybsn-repl
+++ b/bin/pybsn-repl
@@ -37,10 +37,11 @@ parser.add_argument('--host', '-H', type=str, default="127.0.0.1", help="Control
 parser.add_argument('--token', '-t', type=str, help="Session/Token to use")
 parser.add_argument('--user', '-u', type=str, default="admin", help="Username")
 parser.add_argument('--password', '-p', type=str, default="adminadmin", help="Password")
-parser.add_argument('--verbose', '-v', action="store_true", help="Debug output")
+parser.add_argument('--verbose', '-v', action="count", default=0, help="Debug output")
 
 args = parser.parse_args()
-logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+logging.basicConfig(level=logging.DEBUG if args.verbose > 0 else logging.INFO)
+logging.getLogger("pybsn").setLevel(logging.DEBUG if args.verbose > 1 else logging.INFO)
 
 if args.token:
     ctrl = pybsn.connect(host=args.host, token=args.token, login=False)

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -160,13 +160,15 @@ def logged_request(session, request):
     prepared = session.prepare_request(request)
 
     marker = "-" * 30
-    logger.debug("%s Request: %s\n%s\n%s\n\n%s", marker, marker, prepared.method + ' ' + prepared.url,
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("%s Request: %s\n%s\n%s\n\n%s", marker, marker, prepared.method + ' ' + prepared.url,
                   '\n'.join('{}: {}'.format(k, v) for k, v in prepared.headers.items()),
                   prepared.body)
 
     response = session.send(prepared)
 
-    logger.debug("%s Response: %s\n%s\n%s\n\n%s", marker, marker, response.status_code,
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("%s Response: %s\n%s\n%s\n\n%s", marker, marker, response.status_code,
                   '\n'.join('{}: {}'.format(k, v) for k, v in response.headers.items()),
                   response.content)
 

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -97,7 +97,11 @@ class BigDbClient(object):
         return self.request("GET", path, params=params).json()
 
     def rpc(self, path, data):
-         return self.request("POST", path, data=self._dump_if_present(data), rpc=True).json()
+        response = self.request("POST", path, data=self._dump_if_present(data), rpc=True)
+        if response.status_code == requests.codes.no_content:
+            return None
+        else:
+            return response.json()
 
     def post(self, path, data):
         return self.request("POST", path, data=self._dump_if_present(data))

--- a/pybsn/__init__.py
+++ b/pybsn/__init__.py
@@ -12,6 +12,8 @@ try:
 except ImportError:
     pass
 
+logger = logging.getLogger("pybsn")
+
 DATA_PREFIX = "/api/v1/data/"
 RPC_PREFIX = "/api/v1/rpc/"
 SCHEMA_PREFIX = "/api/v1/schema/"
@@ -72,15 +74,17 @@ class Node(object):
         return "Node(%s)" % self._path
 
 class BigDbClient(object):
-    def __init__(self, url, session, verify=True):
+    def __init__(self, url, session):
         self.url = url
         self.session = session
         self.root = Node("controller", self)
-        self.verify = verify
 
     def request(self, method, path, data=None, params=None, rpc=False):
         url = self.url + (RPC_PREFIX if rpc else DATA_PREFIX) + path
-        response = self.session.request(method, url, data=data, params=params, verify=self.verify)
+
+        request = requests.Request(method=method, url=url, data=data, params=params)
+        response = logged_request(self.session, request)
+
         try:
             # Raise an HTTPError for 4xx/5xx codes
             response.raise_for_status()
@@ -123,17 +127,36 @@ class BigDbClient(object):
 
     def schema(self, path=""):
         url = self.url + SCHEMA_PREFIX + path
-        response = self.session.get(url, verify=self.verify)
+        response = self.session.get(url)
         response.raise_for_status()
         return json.loads(response.text)
 
     def __repr__(self):
         return "BigDbClient(%s)" % self.url
 
+
 BIGDB_PROTO_PORTS = [
     ('https', 8443),
     ('http', 8080),
 ]
+
+
+def logged_request(session, request):
+    prepared = session.prepare_request(request)
+
+    marker = "-" * 30
+    logger.debug("%s Request: %s\n%s\n%s\n\n%s", marker, marker, prepared.method + ' ' + prepared.url,
+                  '\n'.join('{}: {}'.format(k, v) for k, v in prepared.headers.items()),
+                  prepared.body)
+
+    response = session.send(prepared)
+
+    logger.debug("%s Response: %s\n%s\n%s\n\n%s", marker, marker, response.status_code,
+                  '\n'.join('{}: {}'.format(k, v) for k, v in response.headers.items()),
+                  response.content)
+
+    return response
+
 
 def guess_url(session, host, validate_path="/api/v1/auth/healthy"):
     if re.match(r'^https?://', host):
@@ -144,18 +167,19 @@ def guess_url(session, host, validate_path="/api/v1/auth/healthy"):
             try:
                 response = session.get(url + validate_path, timeout=2)
             except requests.exceptions.ConnectionError as e:
-                logging.debug("Error connecting to %s: %s", url, str(e))
+                logger.debug("Error connecting to %s: %s", url, str(e))
                 continue
             if response.status_code == 200: # OK
                 return url
             else:
-                logging.debug("Could connect to URL %s: %s", url, response)
+                logger.debug("Could connect to URL %s: %s", url, response)
     raise Exception("Could not find available BigDB service on {}".format(host))
 
-def attempt_login(session, url, username, password, verify):
+def attempt_login(session, url, username, password):
     auth_data = json.dumps({ 'user': username, 'password': password })
     path = "/api/v1/auth/login"
-    response = session.post(url + path, auth_data, verify=verify)
+    request = requests.Request(method="POST", url=url + path, data=auth_data)
+    response = logged_request(session, request)
     if response.status_code == 200: # OK
         # Fix up cookie path
         for cookie in session.cookies:
@@ -165,20 +189,21 @@ def attempt_login(session, url, username, password, verify):
     else:
         response.raise_for_status()
 
-def connect(host, username=None, password=None, verify=False, token=None, login=None, verify_tls=False):
+def connect(host, username=None, password=None, token=None, login=None, verify_tls=False):
     session = requests.Session()
     session.verify = verify_tls
     url = guess_url(session, host)
     if login is None:
-        login = (token is None)
+        login = (token is None) and username is not None and password is not None
 
     if login:
-        attempt_login(session=session, url=url, username=username, password=password, verify=verify)
+        attempt_login(session=session, url=url, username=username, password=password)
     elif token:
         cookie = requests.cookies.create_cookie(name="session_cookie", value=token)
         session.cookies.set_cookie(cookie)
-        response = session.get(url + "/api/v1/data/controller/core/aaa/auth-context")
+        request = requests.Request(method="GET", url=url + "/api/v1/data/controller/core/aaa/auth-context")
+        response = logged_request(session, request)
         if response.status_code != 200:
             response.raise_for_status()
 
-    return BigDbClient(url, session, verify=verify)
+    return BigDbClient(url, session)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+responses
 nose
 requests
 betamax

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 responses
 nose
 requests
-betamax

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ setup(name='pybsn',
     install_requires=[
     "requests >= 2.3.0"
     ],
+    tests_require=[
+        "responses >= 0.10.6"
+    ],
     scripts=['bin/pybsn-repl', 'bin/pybsn-schema'],
     test_suite="test",
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pybsn',
-    version='0.2.0',
+    version='0.3.0',
     description="pybsn is a python interface to Big Switch Networks' products",
     url='https://github.com/floodlight/pybsn',
     author='Jason Parraga, Rich Lane, Andreas Wundsam',

--- a/test/test_bigdb_client.py
+++ b/test/test_bigdb_client.py
@@ -1,0 +1,114 @@
+import json
+import os
+import logging
+import unittest
+
+import requests
+
+import pybsn
+import responses
+
+my_dir = os.path.dirname(__file__)
+
+class TestBigDbClient(unittest.TestCase):
+    def setUp(self):
+        self.client = pybsn.connect("http://127.0.0.1:8080")
+
+    @responses.activate
+    def test_connect_login(self):
+        def _login_cb(req):
+            self.assertEqual(json.loads(req.body), {'user': 'admin', 'password': 'somepassword'})
+            headers = {
+                "Set-Cookie": "session_cookie=v_8yOI7FI-WKr-5QU6nxoJkVtAu5rKI-; Path=/api/;"
+            }
+            return (200, headers, json.dumps(
+                {"success": True,
+                 "session_cookie": "UPhNWlmDN0re8cg9xsqe9QT1QvQTznji",
+                 "error_message": "",
+                 "past_login_info":
+                     {"failed_login_count": 0,
+                      "last_success_login_info": {"host": "127.0.0.1", "timestamp": "2019-05-19T19:16:22.328Z"}}}))
+
+        responses.add_callback(responses.POST, "http://127.0.0.1:8080/api/v1/auth/login", callback=_login_cb,
+                               content_type="application/json")
+
+        client = pybsn.connect("http://127.0.0.1:8080", "admin", "somepassword")
+
+        # Responses is currently broken in that it doesn't retain the session cookies...
+        # https://github.com/getsentry/responses/issues/80
+        #
+        # self.assertEqual(client.session.cookies, {"Cookie": "session_cookie=UPhNWlmDN0re8cg9xsqe9QT1QvQTznji"})
+        #
+        # def _get_cb(req):
+        #     self.assertEqual(req.headers["Cookie"], "session_cookie=UPhNWlmDN0re8cg9xsqe9QT1QvQTznji")
+        #     return (200, {}, json.dumps([ "ok" ]))
+        #
+        # responses.add_callback(responses.GET, "http://127.0.0.1:8080/api/v1/data/controller/test", callback=_get_cb,
+        #                        content_type="application/json")
+        # client.get("controller/test")
+
+    @responses.activate
+    def test_connect_wrong_pw(self):
+        def _login_cb(req):
+            self.assertEqual(json.loads(req.body), {'user': 'admin', 'password': 'foo'})
+            headers = {
+                "Set-Cookie": "session_cookie=v_8yOI7FI-WKr-5QU6nxoJkVtAu5rKI-; Path=/api/;"
+            }
+            return (401, headers, json.dumps(
+                {"success":False,
+                 "session_cookie":None,
+                 "error_message":"Invalid user/password combination.",
+                 "past_login_info":None}))
+
+        responses.add_callback(responses.POST, "http://127.0.0.1:8080/api/v1/auth/login", callback=_login_cb,
+                               content_type="application/json")
+
+        with self.assertRaises(requests.exceptions.HTTPError) as context:
+            pybsn.connect("http://127.0.0.1:8080", "admin", "foo")
+        self.assertEqual(context.exception.response.status_code, 401)
+
+    @responses.activate
+    def test_connect_token(self):
+        def _aaa_cb(req):
+            self.assertEqual(req.headers["Cookie"], "session_cookie=some_token")
+            return (200, {}, json.dumps([ {  "auth-context-type" : "session-token",  "user-info" :
+                              {   "full-name" : "Default admin",
+                             "group" : [ "admin" ],    "user-name" : "admin"  } } ])
+                    )
+
+        responses.add_callback(responses.GET, "http://127.0.0.1:8080/api/v1/data/controller/core/aaa/auth-context",
+                               callback=_aaa_cb, content_type="application/json")
+
+        pybsn.connect("http://127.0.0.1:8080", token="some_token")
+
+    @responses.activate
+    def test_connect_token_wrong(self):
+        def _aaa_cb(req):
+            self.assertEqual(req.headers["Cookie"], "session_cookie=wrong_token")
+            return (401, {}, json.dumps({
+                "description":"Authorization failed: No session or token found for cookie",
+                "error-code":401
+            }))
+
+        responses.add_callback(responses.GET, "http://127.0.0.1:8080/api/v1/data/controller/core/aaa/auth-context",
+                               callback=_aaa_cb, content_type="application/json")
+
+        with self.assertRaises(requests.exceptions.HTTPError) as context:
+            pybsn.connect("http://127.0.0.1:8080", token="wrong_token")
+        self.assertEqual(context.exception.response.status_code, 401)
+
+    @responses.activate
+    def test_rpc(self):
+        responses.add(responses.POST, "http://127.0.0.1:8080/api/v1/rpc/controller/rpc",
+                      json={'id': 1234}, status=200)
+        result = self.client.rpc(path="controller/rpc",
+                                 data={"description": "desc"})
+        self.assertEqual(result, {'id': 1234})
+
+    @responses.activate
+    def test_no_response(self):
+        responses.add(responses.POST, "http://127.0.0.1:8080/api/v1/rpc/controller/rpc",
+                      status=204)
+        result = self.client.rpc(path="controller/rpc",
+                                 data={"description": "desc"})
+        self.assertIsNone(result)

--- a/test/test_switch.py
+++ b/test/test_switch.py
@@ -1,25 +1,58 @@
+import copy
+import json
+import logging
 import os
+import sys
 import unittest
+from contextlib import contextmanager
 
-from betamax import Betamax
+import responses
 from pybsn.bcf.api import Api
 
-pybsn_host = os.environ.get('PYBSN_HOST', 'http://127.0.0.1:8080')
-pybsn_user = os.environ.get('PYBSN_USER', 'admin')
-pybsn_pass = os.environ.get('PYBSN_PASS', 'admin')
+
+pybsn_host = "http://127.0.0.1:8080"
 
 my_dir = os.path.dirname(__file__)
 
-with Betamax.configure() as config:
-    config.cassette_library_dir = os.path.join(my_dir, 'fixtures/cassettes/switch')
-    config.define_cassette_placeholder('<PYBSN_HOST>', pybsn_host)
+logging.basicConfig()
+
+
+@contextmanager
+def responses_from_cassette(cassette):
+    with responses.RequestsMock() as rsps:
+        with open(os.path.join(my_dir, 'fixtures/cassettes/switch',cassette + ".json")) as file_:
+            json_ = json.load(file_)
+
+        def _handle_interaction_cb(req, interaction):
+            if interaction["request"]["body"]["string"]:
+                expected_req_body = json.loads(interaction["request"]["body"]["string"])
+                assert json.loads(req.body) == expected_req_body
+
+            return (interaction["response"]["status"]["code"], interaction["response"]["headers"],
+                    interaction["response"]["body"]["string"])
+
+        for h in json_["http_interactions"]:
+            url = h["request"]["uri"].replace("<PYBSN_HOST>", pybsn_host)
+            if sys.version_info < (3,0):
+                # python2 hack - py2 quotes the square brackets, py3 does not
+                url = url.replace("[", "%5B").replace("]", "%5D")
+            method = h["request"]["method"]
+            cb = lambda req, interaction=h: _handle_interaction_cb(req, interaction)
+            rsps.add_callback(method, url,
+                 callback = cb,
+                 content_type = "application/json")
+
+            print("registered callback %s %s" % (method, url))
+
+        yield
+
 
 class TestSwitch(unittest.TestCase):
     def setUp(self):
-        self.api = Api(pybsn_host, pybsn_user, pybsn_pass, login=False)
+        self.api = Api('http://127.0.0.1:8080', "admin", "pass", login=False)
 
     def test_get_switches(self):
-        with Betamax(self.api.client.session).use_cassette('get_switches'):
+        with responses_from_cassette('get_switches'):
             switches = self.api.get_switches()
 
             assert len(switches) == 14
@@ -30,22 +63,20 @@ class TestSwitch(unittest.TestCase):
 
 
     def test_get_switch_by_name(self):
-        with Betamax(self.api.client.session).use_cassette('get_switch_by_name'):
+        with responses_from_cassette('get_switch_by_name'):
             sw = self.api.get_switch_by_name("test")
 
             assert sw is not None
             assert sw.name == "test"
 
-
     def test_get_switch_by_name_fail(self):
-        with Betamax(self.api.client.session).use_cassette('get_switch_by_name_fail'):
+        with responses_from_cassette('get_switch_by_name_fail'):
             sw = self.api.get_switch_by_name("test")
 
             assert sw is None
 
-
     def test_remove_switch_by_name(self):
-        with Betamax(self.api.client.session).use_cassette('remove_switch_by_name'):
+        with responses_from_cassette('remove_switch_by_name'):
             # Add a switch first
             self.api.add_switch(dpid="00:00:00:00:01:01:01:01", name="test")
 
@@ -56,13 +87,12 @@ class TestSwitch(unittest.TestCase):
             # Remove it
             self.api.remove_switch_by_name("test")
 
-        with Betamax(self.api.client.session).use_cassette('remove_switch_by_name_2'):
+        with responses_from_cassette('remove_switch_by_name_2'):
             sw = self.api.get_switch_by_name("test")
             assert sw is None
 
-
     def test_remove_switch_by_dpid(self):
-        with Betamax(self.api.client.session).use_cassette('remove_switch_by_dpid'):
+        with responses_from_cassette('remove_switch_by_dpid'):
             # Add a switch first
             self.api.add_switch(dpid="00:00:00:00:01:01:01:01", name="test")
 
@@ -73,28 +103,25 @@ class TestSwitch(unittest.TestCase):
             # Remove it
             self.api.remove_switch_by_dpid("00:00:00:00:01:01:01:01")
 
-        with Betamax(self.api.client.session).use_cassette('remove_switch_by_dpid_2'):
+        with responses_from_cassette('remove_switch_by_dpid_2'):
             sw = self.api.get_switch_by_dpid("00:00:00:00:01:01:01:01")
             assert sw is None
 
-
     def test_get_switch_by_dpid(self):
-        with Betamax(self.api.client.session).use_cassette('get_switch_by_dpid'):
+        with responses_from_cassette('get_switch_by_dpid'):
             sw = self.api.get_switch_by_dpid("00:00:00:00:00:01:00:01")
 
             assert sw is not None
             assert sw.dpid == "00:00:00:00:00:01:00:01"
 
-
     def test_get_switch_by_dpid_fail(self):
-        with Betamax(self.api.client.session).use_cassette('get_switch_by_dpid_fail'):
+        with responses_from_cassette('get_switch_by_dpid_fail'):
             sw = self.api.get_switch_by_dpid("00:00:00:00:00:00:00:01")
 
             assert sw is None
 
-
     def test_update(self):
-        with Betamax(self.api.client.session).use_cassette('update'):
+        with responses_from_cassette('update'):
             sw = self.api.get_switch_by_dpid("00:00:00:00:00:01:00:01")
 
             assert sw is not None
@@ -103,10 +130,8 @@ class TestSwitch(unittest.TestCase):
 
             assert sw != None
 
-
     def test_remove(self):
-        with Betamax(self.api.client.session) as vcr:
-            vcr.use_cassette('remove')
+        with responses_from_cassette("remove"):
             # Add a switch first
             self.api.add_switch(dpid="00:00:00:00:01:01:01:01", name="test")
 
@@ -117,13 +142,13 @@ class TestSwitch(unittest.TestCase):
             # Remove it
             sw.remove()
 
-            vcr.use_cassette('get_switch_by_name_fail')
+        with responses_from_cassette("get_switch_by_name_fail"):
             sw = self.api.get_switch_by_name("test")
             assert sw is None
 
 
     def test_add_switch(self):
-        with Betamax(self.api.client.session).use_cassette('add_switch'):
+        with responses_from_cassette('add_switch'):
             sw = self.api.add_switch(dpid="00:00:00:00:01:01:01:01", name="test")
 
             assert sw is not None
@@ -136,7 +161,7 @@ class TestSwitch(unittest.TestCase):
 
 
     def test_disconnect_switch(self):
-        with Betamax(self.api.client.session).use_cassette('disconnect_switch'):
+        with responses_from_cassette('disconnect_switch'):
             switches = self.api.get_switches()
 
             assert len(switches) == 14
@@ -146,7 +171,7 @@ class TestSwitch(unittest.TestCase):
 
 
     def test_get_interfaces(self):
-        with Betamax(self.api.client.session).use_cassette('get_interfaces'):
+        with responses_from_cassette('get_interfaces'):
             sw = self.api.get_switch_by_dpid("00:00:00:00:00:01:00:01")
 
             assert sw is not None
@@ -157,7 +182,7 @@ class TestSwitch(unittest.TestCase):
 
 
     def test_get_connections(self):
-        with Betamax(self.api.client.session).use_cassette('get_connections'):
+        with responses_from_cassette('get_connections'):
             sw = self.api.get_switch_by_dpid("00:00:00:00:00:01:00:01")
 
             assert sw is not None

--- a/test/test_switch.py
+++ b/test/test_switch.py
@@ -2,6 +2,7 @@ import copy
 import json
 import logging
 import os
+import re
 import sys
 import unittest
 from contextlib import contextmanager
@@ -33,12 +34,14 @@ def responses_from_cassette(cassette):
 
         for h in json_["http_interactions"]:
             url = h["request"]["uri"].replace("<PYBSN_HOST>", pybsn_host)
-            if sys.version_info < (3,0):
+            url = re.escape(url)
+            url = url.replace(r'\[', r'(\[|%5B)').replace(r'\]', r'(\]|%5D)')
+            #if True or sys.version_info < (3,0):
                 # python2 hack - py2 quotes the square brackets, py3 does not
-                url = url.replace("[", "%5B").replace("]", "%5D")
+                #url = url.replace("[", "%5B").replace("]", "%5D")
             method = h["request"]["method"]
             cb = lambda req, interaction=h: _handle_interaction_cb(req, interaction)
-            rsps.add_callback(method, url,
+            rsps.add_callback(method, re.compile(url),
                  callback = cb,
                  content_type = "application/json")
 


### PR DESCRIPTION
This PR 
* fixes a bug with the handling of RPC's which return no data (c9836c0)
* adds a `responses` based unit test for `.rpc`
* adds the ability to log request/response bodies, and removes redundant/unused parameter `verify` (9a248f3)
* removes the usage of `betamax`; instead primes `responses` directly with the requests (1d40817)
* fixes pybsn on python2 and re-enables py2 builds (rest).